### PR TITLE
Refactor login and registration

### DIFF
--- a/server/src/QRServer/__main__.py
+++ b/server/src/QRServer/__main__.py
@@ -47,6 +47,7 @@ class ServerThread(Thread):
                 await task
 
         self.run_within_event_loop(_stop_loop())
+        self.loop.close()
 
     def run_within_event_loop(self, coro: Coroutine):
         return asyncio.run_coroutine_threadsafe(coro, self.loop).result()

--- a/server/src/QRServer/db/password.py
+++ b/server/src/QRServer/db/password.py
@@ -17,13 +17,16 @@ def password_hash(password: bytes) -> str:
     return (salt + h).decode('ascii')
 
 
-def password_verify(provided_password: bytes, stored_password: str) -> bool:
-    salt = stored_password[:64]
-    stored_password = stored_password[64:]
+def password_verify(provided_password: bytes, stored_hash: str) -> bool:
+    if not stored_hash or not provided_password:
+        return False
+
+    salt = stored_hash[:64]
+    stored_hash = stored_hash[64:]
     h = hashlib.pbkdf2_hmac(
         _hash_name,
         provided_password,
         salt.encode('ascii'),
         _iterations)
     h = binascii.hexlify(h).decode('ascii')
-    return h == stored_password
+    return h == stored_hash

--- a/server/tests/test_cli.py
+++ b/server/tests/test_cli.py
@@ -8,7 +8,10 @@ from QRServer.cli import QRCmd
 class DummyServer:
     def run_within_event_loop(self, coro: Coroutine):
         loop = asyncio.new_event_loop()
-        return loop.run_until_complete(coro)
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
 
 class CliTest(unittest.TestCase):


### PR DESCRIPTION
Closes #77 

Always add user to db, regardless of config, refactor db query to automatically create user if not exists (and desired) with one query.