### PR TITLE
Inform the user that Quadradius does not work when the tab is inactive

### DIFF
--- a/docker/qr/http/index.html
+++ b/docker/qr/http/index.html
@@ -73,9 +73,23 @@
         }
     </style>
     <script type="application/javascript">
+        const originalTitle = document.title;
         window.onbeforeunload = function () {
             return 'Are you sure you want to leave?';
         };
+
+        document.addEventListener('visibilitychange', function () {
+            if (document.hidden) {
+                document.title = originalTitle + " (Paused)";
+                alert('Quadradius cannot work properly when the tab is in the background and has to be paused. ' +
+                    'You WILL be timed out after some time when Quadradius is paused. ' +
+                    'This is the current limitation of Ruffle.\n\n' +
+                    'If you want to run Quadradius in the background, ' +
+                    'currently the best solution is to keep it open in a new window.');
+            } else {
+                document.title = originalTitle;
+            }
+        });
     </script>
 </head>
 


### PR DESCRIPTION
Hopefully this will communicate better that Quadradius does not work when the tab is inactive.