### PR TITLE
Remove default titles from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: "Bug report"
 description: File a bug report.
-title: "[BUG] <title>"
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: "Feature Request"
 description: Request a feature to be added.
-title: "[FEATURE] <title>"
 labels: ["enhancement"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/refactor_request.yml
+++ b/.github/ISSUE_TEMPLATE/refactor_request.yml
@@ -1,6 +1,5 @@
 name: "Refactor Request"
 description: Request to change code to make it easier to maintain, avoid bugs and technical debt.
-title: "[REFACTOR] <title>"
 labels: ["refactor"]
 body:
   - type: markdown


### PR DESCRIPTION
Prefixes do not matter, as issues have labels, and the `<title>` portion only confuses people.