### PR TITLE
Improve is_guest detection for users

### DIFF
--- a/server/src/QRServer/db/models.py
+++ b/server/src/QRServer/db/models.py
@@ -16,7 +16,7 @@ class DbUser:
 
     @property
     def is_guest(self):
-        return 'GUEST' in self.username and self.password is None
+        return self.username.lower().endswith(' guest')
 
 
 @dataclass


### PR DESCRIPTION
It's enough to check if a username ends with " guest", because members cannot create accounds ending with " guest", and that's the condition players use when differentiating members from guests.

**This is not tested, requires testing.**