### PR TITLE
feat: add ranking table

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.egg-info
 /build/
 /dist/
+.pytest_cache

--- a/server/src/QRServer/common/classes.py
+++ b/server/src/QRServer/common/classes.py
@@ -182,7 +182,8 @@ class GameResultHistory:
 
 @dataclass
 class RankingEntry:
-    player: str
+    username: str
+    user_id: str
     wins: int
     games: int
 

--- a/server/src/QRServer/common/messages.py
+++ b/server/src/QRServer/common/messages.py
@@ -437,7 +437,7 @@ class ServerRankingThisMonthResponse(ResponseMessage):
     @classmethod
     def __serialize_entry(cls, entry: RankingEntry):
         return [
-            entry.player,
+            entry.username,
             str(entry.wins),
             str(entry.games),
         ]

--- a/server/src/QRServer/common/utils.py
+++ b/server/src/QRServer/common/utils.py
@@ -2,6 +2,7 @@ import hashlib
 from datetime import datetime
 import secrets
 import string
+from typing import List
 
 
 def is_guest(username: str, password: str):
@@ -10,6 +11,8 @@ def is_guest(username: str, password: str):
 
 
 def make_month_dates(month: int, year: int) -> tuple[datetime, datetime]:
+    # Returns tuple consisting of the first day of the given month and year and
+    # the first day of the next month (incrementing year if needed)
     return \
         datetime(year, month, 1), \
         datetime(year + month // 12, (month % 12) + 1, 1)
@@ -17,3 +20,26 @@ def make_month_dates(month: int, year: int) -> tuple[datetime, datetime]:
 
 def generate_random_password(length: int) -> str:
     return ''.join([secrets.choice(string.ascii_letters + string.digits) for _ in range(length)])
+
+
+def make_month_dates_range(start_date: datetime, end_date: datetime) -> List[datetime]:
+    # Returns a list of datetimes between the start_date and end_date (end inclusive)
+    if start_date > end_date:
+        return []
+
+    current_month = start_date.month
+    current_year = start_date.year
+
+    end_month = end_date.month
+    end_year = end_date.year
+
+    res = []
+
+    while True:
+        res.append(datetime(year=current_year, month=current_month, day=1))
+
+        if current_month >= end_month and current_year >= end_year:
+            return res
+        else:
+            current_year += current_month // 12
+            current_month = (current_month % 12) + 1

--- a/server/src/QRServer/db/migrations.py
+++ b/server/src/QRServer/db/migrations.py
@@ -1,3 +1,8 @@
+from datetime import datetime as dt
+from QRServer.common import utils
+from QRServer.common.classes import RankingEntry
+
+
 async def setup_metadata(c):
     await c.execute(
         "create table if not exists metadata ("
@@ -6,54 +11,24 @@ async def setup_metadata(c):
         ")")
 
 
-async def execute_migrations(c):
+async def execute_migrations(c, config, max_version=None):
     version = await _select_version(c)
     if version is None:
         await c.execute("insert into metadata (name, value) values ('version', '0')")
         version = 0
 
-    if version <= 0:
-        await c.execute(
-            "create table users ("
-            "  id varchar primary key,"
-            "  username varchar unique,"
-            "  password varchar"
-            ")")
-        await _set_version(c, 1)
-    if version <= 1:
-        await c.execute("alter table users add column comment varchar")
-        await _set_version(c, 2)
-    if version <= 2:
-        await c.execute(
-            "create table matches ("
-            "  id varchar primary key,"
-            "  winner_id varchar,"
-            "  loser_id varchar,"
-            "  winner_pieces_left integer,"
-            "  loser_pieces_left integer,"
-            "  move_counter integer,"
-            "  grid_size varchar,"
-            "  squadron_size varchar,"
-            "  started_at integer,"
-            "  finished_at integer,"
-            "  is_ranked integer,"
-            "  is_void integer,"
-            "  foreign key(winner_id) references users (id),"
-            "  foreign key(loser_id) references users (id)"
-            ")")
-        await _set_version(c, 3)
-    if version <= 3:
-        await c.execute(
-            "alter table users"
-            " add column created_at integer"
-        )
-        await _set_version(c, 4)
-    if version <= 4:
-        await c.execute(
-            "alter table users"
-            " add column discord_user_id varchar"
-        )
-        await _set_version(c, 5)
+    migrations = [
+        _migration_upgrade_to_v1,
+        _migration_upgrade_to_v2,
+        _migration_upgrade_to_v3,
+        _migration_upgrade_to_v4,
+        _migration_upgrade_to_v5,
+        _migration_upgrade_to_v6,
+    ]
+
+    for i in range(max_version if max_version and max_version <= len(migrations) else len(migrations)):
+        if version <= i:
+            await migrations[i](c, config)
 
 
 async def _select_version(c):
@@ -64,3 +39,148 @@ async def _select_version(c):
 
 async def _set_version(c, version):
     await c.execute("update metadata set value = ? where name='version'", (version,))
+
+
+# # # # # # # #
+# Migrations  #
+# # # # # # # #
+async def _migration_upgrade_to_v1(c, _config):
+    await c.execute(
+            "create table users ("
+            "  id varchar primary key,"
+            "  username varchar unique,"
+            "  password varchar"
+            ")")
+    await _set_version(c, 1)
+
+
+async def _migration_upgrade_to_v2(c, _config):
+    await c.execute("alter table users add column comment varchar")
+    await _set_version(c, 2)
+
+
+async def _migration_upgrade_to_v3(c, _config):
+    await c.execute(
+        "create table matches ("
+        "  id varchar primary key,"
+        "  winner_id varchar,"
+        "  loser_id varchar,"
+        "  winner_pieces_left integer,"
+        "  loser_pieces_left integer,"
+        "  move_counter integer,"
+        "  grid_size varchar,"
+        "  squadron_size varchar,"
+        "  started_at integer,"
+        "  finished_at integer,"
+        "  is_ranked integer,"
+        "  is_void integer,"
+        "  foreign key(winner_id) references users (id),"
+        "  foreign key(loser_id) references users (id)"
+        ")")
+    await _set_version(c, 3)
+
+
+async def _migration_upgrade_to_v4(c, _config):
+    await c.execute(
+        "alter table users"
+        " add column created_at integer"
+    )
+    await _set_version(c, 4)
+
+
+async def _migration_upgrade_to_v5(c, _config):
+    await c.execute(
+        "alter table users"
+        " add column discord_user_id varchar"
+    )
+    await _set_version(c, 5)
+
+
+async def _migration_upgrade_to_v6(c, config):
+    await c.execute(
+        "create table rankings ("
+        "  year integer,"
+        "  month integer,"
+        "  position integer,"
+        "  user_id varchar,"
+        "  wins integer,"
+        "  total_games integer,"
+        "  primary key (year, month, position),"
+        "  foreign key(user_id) references users (id)"
+        ")"
+    )
+    await c.execute(
+        "select started_at"
+        " from matches"
+        " order by started_at asc"
+        " limit 1"
+    )
+    row = await c.fetchone()
+    if row:
+        first_timestamp = row[0]
+        first_dt = dt.fromtimestamp(first_timestamp)
+        dates_range = utils.make_month_dates_range(start_date=first_dt, end_date=dt.now())
+
+        ranked_only = config.leaderboards_ranked_only.get()
+        include_void = config.leaderboards_include_void.get()
+
+        for date in dates_range:
+            start_date, end_date = utils.make_month_dates(date.month, date.year)
+
+            # Generate rankings - same as the dbconnector's function at the time of writing
+            await c.execute(
+                "select"
+                " u.username,"
+                " u.id,"
+                " sum(m.winner_id = u.id) as total_wins,"
+                " count(*) as total_games,"
+                " (sum(m.winner_id = u.id) * 1.0 / count(*)) as win_percentage"
+                " from users u"
+                " inner join matches m on (u.id = m.winner_id or u.id = m.loser_id)"
+                " where m.finished_at >= ?"
+                " and m.finished_at < ?"
+                " and (case when ? = 1 then m.is_ranked = 1 else 1=1 end)"
+                " and (case when ? = 0 then m.is_void = 0 else 1=1 end)"
+                " group by u.username"
+                " order by win_percentage desc, total_wins desc"
+                " limit 100", (
+                    start_date.timestamp(),
+                    end_date.timestamp(),
+                    1 if ranked_only else 0,
+                    1 if include_void else 0
+                )
+            )
+
+            ranking_entries = []
+            rows = await c.fetchall()
+            for row in rows:
+                ranking_entries.append(RankingEntry(
+                    username=row[0],
+                    user_id=row[1],
+                    wins=row[2],
+                    games=row[3],
+                ))
+
+            # end
+            if ranking_entries:
+                for position, entry in enumerate(ranking_entries):
+                    await c.execute(
+                        "insert or replace into rankings ("
+                        "  year,"
+                        "  month,"
+                        "  position,"
+                        "  user_id,"
+                        "  wins,"
+                        "  total_games"
+                        ") values ("
+                        "?, ?, ?, ?, ?, ?"
+                        ")", (
+                            date.year,
+                            date.month,
+                            position+1,
+                            entry.user_id,
+                            entry.wins,
+                            entry.games,
+                        ))
+
+    await _set_version(c, 6)

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -1,16 +1,19 @@
+from typing import List, Tuple
 import unittest
 from datetime import datetime
 from unittest.mock import patch
 from QRServer.common.classes import GameResultHistory
+from QRServer.db import migrations
 from QRServer.db.connector import DbConnector
 from QRServer.db.models import DbMatchReport
 from QRServer.common.classes import RankingEntry
 from QRServer.common import utils
+from QRServer.config import Config
 
 
 class DbTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
-        self.conn = DbConnector(':memory:')
+        self.conn = DbConnector(':memory:', Config())
         await self.conn.connect()
 
     async def asyncTearDown(self):
@@ -79,6 +82,19 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
             loser = await self.conn.get_user(loser.user_id)
             self.assertEqual(loser.user_id, loser.user_id)
             self.assertEqual(loser.username, 'test_user_2')
+
+            ranking = await self.conn.get_ranking(
+                start_date=datetime(2020, 1, 1, 0, 0, 0),
+                end_date=datetime(2020, 1, 2, 0, 0, 0))
+            self.assertEqual(len(ranking), 2)
+            self.assertEqual(ranking[0].username, 'test_user_1')
+            self.assertEqual(ranking[0].user_id, '1')
+            self.assertEqual(ranking[0].wins, 1)
+            self.assertEqual(ranking[0].games, 1)
+            self.assertEqual(ranking[1].username, 'test_user_2')
+            self.assertEqual(ranking[1].user_id, '2')
+            self.assertEqual(ranking[1].wins, 0)
+            self.assertEqual(ranking[1].games, 1)
 
     async def test_get_nonexistent_match(self):
         match = await self.conn.get_match('1234')
@@ -261,47 +277,16 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
 
                 await self.conn.add_match_result(test_match)
 
-            ranking_entries_default = [
-                RankingEntry(player='test_user_0', wins=7, games=7),
-                RankingEntry(player='test_user_1', wins=5, games=5),
-                RankingEntry(player='test_user_2', wins=10, games=22),
-                RankingEntry(player='test_user_3', wins=0, games=10),
+            ranking_entries = [
+                RankingEntry(username='test_user_0', user_id='0', wins=7, games=7),
+                RankingEntry(username='test_user_1', user_id='1', wins=5, games=5),
+                RankingEntry(username='test_user_2', user_id='2', wins=10, games=22),
+                RankingEntry(username='test_user_3', user_id='3', wins=0, games=10),
             ]
-
-            ranking_entries_unranked = [
-                RankingEntry(player='test_user_0', wins=7, games=7),
-                RankingEntry(player='test_user_1', wins=5, games=5),
-                RankingEntry(player='test_user_2', wins=12, games=24),
-                RankingEntry(player='test_user_3', wins=0, games=12),
-            ]
-
-            ranking_entries_void = [
-                RankingEntry(player='test_user_0', wins=7, games=7),
-                RankingEntry(player='test_user_1', wins=5, games=5),
-                RankingEntry(player='test_user_2', wins=13, games=25),
-                RankingEntry(player='test_user_3', wins=0, games=13),
-            ]
-
-            ranking_entries_full = [
-                RankingEntry(player='test_user_0', wins=7, games=7),
-                RankingEntry(player='test_user_1', wins=5, games=5),
-                RankingEntry(player='test_user_2', wins=15, games=27),
-                RankingEntry(player='test_user_3', wins=0, games=15),
-            ]
-
             start_date, end_date = utils.make_month_dates(month=1, year=2020)
 
-            self.assertEqual(ranking_entries_default, await self.conn.get_ranking(
+            self.assertEqual(ranking_entries, await self.conn.get_ranking(
                 start_date=start_date, end_date=end_date
-            ))
-            self.assertEqual(ranking_entries_unranked, await self.conn.get_ranking(
-                start_date=start_date, end_date=end_date, ranked_only=False
-            ))
-            self.assertEqual(ranking_entries_void, await self.conn.get_ranking(
-                start_date=start_date, end_date=end_date, include_void=True
-            ))
-            self.assertEqual(ranking_entries_full, await self.conn.get_ranking(
-                start_date=start_date, end_date=end_date, include_void=True, ranked_only=False
             ))
 
     async def test_create_member(self):
@@ -318,3 +303,182 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(user.created_at, datetime(2020, 1, 1, 0, 0, 0).timestamp())
             self.assertEqual(user.discord_user_id, '11111111111')
             self.assertFalse(user.is_guest)
+
+
+class DbMigrationTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        import aiosqlite
+
+        self.dbconn = DbConnector(':memory:', Config())
+        # manually initialize the dbconn to avoid executing migrations
+        self.dbconn.conn = await aiosqlite.connect(':memory:', autocommit=False)
+        c = await self.dbconn.conn.cursor()
+        await migrations.setup_metadata(c)
+        await self.dbconn.conn.commit()
+        self.c = await self.dbconn.conn.cursor()
+
+    async def asyncTearDown(self):
+        await self.dbconn.conn.close()
+
+    async def get_table_names(self) -> List[str]:
+        # Utility to pull the names of the existing tables
+        # Flattens them to list of strings from tuples
+        await self.c.execute("select name from sqlite_master where type='table';")
+        tables = await self.c.fetchall()
+        return [i[0] for i in tables]
+
+    async def get_table_info(self, table_name: str) -> List[Tuple]:
+        await self.c.execute(f'pragma table_info(\'{table_name}\')')
+        return await self.c.fetchall()
+
+    async def test_migration_v1(self):
+        self.assertNotIn('users', await self.get_table_names())
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 1)
+
+        self.assertIn('users', await self.get_table_names())
+        table_info = await self.get_table_info('users')
+
+        self.assertEqual(len(table_info), 3)
+        self.assertEqual(table_info[0][:3], (0, 'id', 'varchar'))
+        self.assertEqual(table_info[1][:3], (1, 'username', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'password', 'varchar'))
+
+    async def test_migration_v2(self):
+        await migrations.execute_migrations(self.c, self.dbconn.config, 1)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 3)
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 2)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 4)
+        self.assertEqual(table_info[3][:3], (3, 'comment', 'varchar'))
+
+    async def test_migration_v3(self):
+        await migrations.execute_migrations(self.c, self.dbconn.config, 2)
+
+        self.assertNotIn('matches', await self.get_table_names())
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 3)
+
+        self.assertIn('matches', await self.get_table_names())
+        table_info = await self.get_table_info('matches')
+        self.assertEqual(len(table_info), 12)
+        self.assertEqual(table_info[0][:3], (0, 'id', 'varchar'))
+        self.assertEqual(table_info[1][:3], (1, 'winner_id', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'loser_id', 'varchar'))
+        self.assertEqual(table_info[3][:3], (3, 'winner_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[4][:3], (4, 'loser_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[5][:3], (5, 'move_counter', 'INTEGER'))
+        self.assertEqual(table_info[6][:3], (6, 'grid_size', 'varchar'))
+        self.assertEqual(table_info[7][:3], (7, 'squadron_size', 'varchar'))
+        self.assertEqual(table_info[8][:3], (8, 'started_at', 'INTEGER'))
+        self.assertEqual(table_info[9][:3], (9, 'finished_at', 'INTEGER'))
+        self.assertEqual(table_info[10][:3], (10, 'is_ranked', 'INTEGER'))
+        self.assertEqual(table_info[11][:3], (11, 'is_void', 'INTEGER'))
+
+    async def test_migration_v4(self):
+        await migrations.execute_migrations(self.c, self.dbconn.config, 3)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 4)
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 4)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 5)
+        self.assertEqual(table_info[4][:3], (4, 'created_at', 'INTEGER'))
+
+    async def test_migration_v5(self):
+        await migrations.execute_migrations(self.c, self.dbconn.config, 4)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 5)
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 5)
+
+        table_info = await self.get_table_info('users')
+        self.assertEqual(len(table_info), 6)
+        self.assertEqual(table_info[5][:3], (5, 'discord_user_id', 'varchar'))
+
+    async def test_migration_v6(self):
+        await migrations.execute_migrations(self.c, self.dbconn.config, 5)
+
+        with patch('uuid.uuid4') as mock_uuid:
+            mock_uuid.return_value = '1'
+            winner = await self.dbconn.authenticate_user('test_user_1', b'password', auto_create=True)
+
+            mock_uuid.return_value = '2'
+            loser = await self.dbconn.authenticate_user('test_user_2', b'password', auto_create=True)
+
+            mock_uuid.return_value = '1234'
+            test_match = DbMatchReport(
+                winner_id=winner.user_id,
+                loser_id=loser.user_id,
+                winner_pieces_left=10,
+                loser_pieces_left=5,
+                move_counter=20,
+                grid_size='small',
+                squadron_size='medium',
+                started_at=datetime(2020, 1, 1, 0, 0, 0),
+                finished_at=datetime(2020, 1, 1, 1, 0, 0),
+                is_ranked=True,
+                is_void=False,
+            )
+            await self.c.execute(
+                "insert into matches ("
+                "  id,"
+                "  winner_id,"
+                "  loser_id,"
+                "  winner_pieces_left,"
+                "  loser_pieces_left,"
+                "  move_counter,"
+                "  grid_size,"
+                "  squadron_size,"
+                "  started_at,"
+                "  finished_at,"
+                "  is_ranked,"
+                "  is_void"
+                ") values ("
+                "?, ?, ?, ?, ?, ?,"
+                "?, ?, ?, ?, ?, ?"
+                ")", (
+                    test_match.match_id,
+                    test_match.winner_id,
+                    test_match.loser_id,
+                    test_match.winner_pieces_left,
+                    test_match.loser_pieces_left,
+                    test_match.move_counter,
+                    test_match.grid_size,
+                    test_match.squadron_size,
+                    test_match.started_at.timestamp(),
+                    test_match.finished_at.timestamp(),
+                    test_match.is_ranked,
+                    test_match.is_void
+                )
+            )
+
+            await self.dbconn.conn.commit()
+
+        self.assertNotIn('rankings', await self.get_table_names())
+
+        await migrations.execute_migrations(self.c, self.dbconn.config, 6)
+
+        self.assertIn('rankings', await self.get_table_names())
+        table_info = await self.get_table_info('rankings')
+        self.assertEqual(len(table_info), 6)
+        self.assertEqual(table_info[0][:3], (0, 'year', 'INTEGER'))
+        self.assertEqual(table_info[1][:3], (1, 'month', 'INTEGER'))
+        self.assertEqual(table_info[2][:3], (2, 'position', 'INTEGER'))
+        self.assertEqual(table_info[3][:3], (3, 'user_id', 'varchar'))
+        self.assertEqual(table_info[4][:3], (4, 'wins', 'INTEGER'))
+        self.assertEqual(table_info[5][:3], (5, 'total_games', 'INTEGER'))
+
+        # TODO self.get_ranking, compare
+        await self.c.execute('select * from rankings')
+        ranking_data = await self.c.fetchall()
+        self.assertEqual(len(ranking_data), 2)
+        self.assertEqual(ranking_data[0], (2020, 1, 1, '1', 1, 1))
+        self.assertEqual(ranking_data[1], (2020, 1, 2, '2', 0, 1))

--- a/server/tests/test_discord_bot.py
+++ b/server/tests/test_discord_bot.py
@@ -15,7 +15,7 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
         self.config.set('discord.bot.max_aliases', 1)
         self.config.set('discord.bot.channel_user_notifications.id', '111')
 
-        self.conn = DbConnector(':memory:')
+        self.conn = DbConnector(':memory:', self.config)
         await self.conn.connect()
 
         self.bot = DiscordBot(self.config, self.conn)

--- a/server/tests/test_messages.py
+++ b/server/tests/test_messages.py
@@ -185,11 +185,13 @@ class ResponseMessagesTest(unittest.TestCase):
     def test_server_ranking_this_month_response(self):
         msg = ServerRankingThisMonthResponse.new([
             RankingEntry(
-                player='test',
+                username='test',
+                user_id='',
                 wins=5,
                 games=20),
             RankingEntry(
-                player='test2',
+                username='test2',
+                user_id='',
                 wins=7,
                 games=7),
         ])

--- a/server/tests/test_utils.py
+++ b/server/tests/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime
+from datetime import datetime as dt
 
 from QRServer.common import utils
 
@@ -8,11 +8,11 @@ class MakeMonthDatesTest(unittest.TestCase):
     def test_make_month_dates(self):
         self.assertEqual(
             utils.make_month_dates(1, 2020),
-            (datetime(2020, 1, 1), datetime(2020, 2, 1))
+            (dt(2020, 1, 1), dt(2020, 2, 1))
         )
         self.assertEqual(
             utils.make_month_dates(12, 2020),
-            (datetime(2020, 12, 1), datetime(2021, 1, 1))
+            (dt(2020, 12, 1), dt(2021, 1, 1))
         )
 
 
@@ -20,3 +20,68 @@ class GenerateRandomPasswordTest(unittest.TestCase):
     def test_generate_random_password(self):
         for i in range(0, 100, 10):
             self.assertEqual(len(utils.generate_random_password(i)), i)
+
+
+class MakeMonthDatesRange(unittest.TestCase):
+    def test_month_dates_range_basic(self):
+        self.assertEqual(
+            utils.make_month_dates_range(
+                dt(2020, 1, 1), dt(2020, 1, 31)
+            ),
+            [
+                dt(2020, 1, 1),
+            ]
+        )
+
+    def test_month_dates_range_random_days_same_month(self):
+        self.assertEqual(
+            utils.make_month_dates_range(
+                dt(2020, 1, 4), dt(2020, 1, 9)
+            ),
+            [
+                dt(2020, 1, 1),
+            ]
+        )
+
+    def test_month_dates_range_start_after_end(self):
+        self.assertEqual(
+            utils.make_month_dates_range(
+                dt(2020, 2, 4), dt(2020, 1, 9)
+            ),
+            [
+            ]
+        )
+
+    def test_month_dates_range_year(self):
+        self.assertEqual(
+            utils.make_month_dates_range(
+                dt(2020, 1, 12), dt(2020, 12, 12)
+            ),
+            [
+                dt(2020, 1, 1),
+                dt(2020, 2, 1),
+                dt(2020, 3, 1),
+                dt(2020, 4, 1),
+                dt(2020, 5, 1),
+                dt(2020, 6, 1),
+                dt(2020, 7, 1),
+                dt(2020, 8, 1),
+                dt(2020, 9, 1),
+                dt(2020, 10, 1),
+                dt(2020, 11, 1),
+                dt(2020, 12, 1),
+            ]
+        )
+
+    def test_month_dates_range_across_year(self):
+        self.assertEqual(
+            utils.make_month_dates_range(
+                dt(2020, 11, 12), dt(2021, 2, 15)
+            ),
+            [
+                dt(2020, 11, 1),
+                dt(2020, 12, 1),
+                dt(2021, 1, 1),
+                dt(2021, 2, 1),
+            ]
+        )


### PR DESCRIPTION
Introduces new ranking table, which is used to provide the current ranking when players join lobby (should slightly help with CPU since it doesn't require recalculation) and will help us retain old leaderboards when the ranking calculation will change