### PR TITLE
Switch unpkg to jsdelivr

### DIFF
--- a/docker/qr/http/index.html
+++ b/docker/qr/http/index.html
@@ -106,7 +106,7 @@
             version = '';
         }
         let ruffleScript = document.createElement("script");
-        ruffleScript.setAttribute("src", `https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle{version}`);
+        ruffleScript.setAttribute("src", `https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle${version}`);
         document.body.appendChild(ruffleScript);
     </script>
 </body>

--- a/docker/qr/http/index.html
+++ b/docker/qr/http/index.html
@@ -106,7 +106,7 @@
             version = '';
         }
         let ruffleScript = document.createElement("script");
-        ruffleScript.setAttribute("src", `https://unpkg.com/@ruffle-rs/ruffle${version}`);
+        ruffleScript.setAttribute("src", `https://cdn.jsdelivr.net/npm/@ruffle-rs/ruffle{version}`);
         document.body.appendChild(ruffleScript);
     </script>
 </body>


### PR DESCRIPTION
unpkg is unreliable.

This patch is untested