### PR TITLE
Enable Ruffle background execution and update version

### DIFF
--- a/docker/qr/http/config-ruffle.js
+++ b/docker/qr/http/config-ruffle.js
@@ -18,6 +18,7 @@ window.RufflePlayer.config = {
             proxyUrl: `${protocol}//${host}/websocket/game`,
         },
     ],
+    backgroundExecutionMode: "mainThread",
     urlRewriteRules: [
         ["http://www.quadradius.com/quadboard", "https://discord.gg/cVkV8pah4d"], // Quadboard
     ],

--- a/docker/qr/http/main.js
+++ b/docker/qr/http/main.js
@@ -3,21 +3,6 @@ window.onbeforeunload = function () {
   return "Are you sure you want to leave?";
 };
 
-document.addEventListener("visibilitychange", function () {
-  if (document.hidden) {
-    document.title = originalTitle + " (Paused)";
-    alert(
-      "Quadradius cannot work properly when the tab is in the background and has to be paused. " +
-        "You WILL be timed out after some time when Quadradius is paused. " +
-        "This is the current limitation of Ruffle.\n\n" +
-        "If you want to run Quadradius in the background, " +
-        "currently the best solution is to keep it open in a new window."
-    );
-  } else {
-    document.title = originalTitle;
-  }
-});
-
 // Load Ruffle
 document.addEventListener("DOMContentLoaded", function () {
   let version = new URLSearchParams(window.location.search).get(
@@ -26,7 +11,7 @@ document.addEventListener("DOMContentLoaded", function () {
   if (version) {
     version = "@" + version + "/ruffle.js";
   } else {
-    version = "@0.1.0-nightly.2025.6.21/ruffle.js";
+    version = "@0.2.0-nightly.2026.4.21/ruffle.js";
   }
   let ruffleScript = document.createElement("script");
   ruffleScript.setAttribute(


### PR DESCRIPTION
The new version of Ruffle supports a background execution method that leverages the main thread to keep the SWF running.  It's currently experimental, but my testing shows it works well with Quadradius.

Most notably, it will prevent Quadradius from timing out. It can be kept in the background waiting for other players to join the lobby.