### PR TITLE
Add SendMessageException()

### DIFF
--- a/server/src/QRServer/common/clienthandler.py
+++ b/server/src/QRServer/common/clienthandler.py
@@ -103,6 +103,12 @@ class ClientHandler(abc.ABC):
             except StopHandlerException:
                 log.debug('Stopping handler')
                 return
+            except SendMessageException as e:
+                if e.username == self.username:
+                    log.debug(f'Failed to send a message to {self.username}, stopping handler')
+                else:
+                    log.exception(f'Unhandled send message exception to {e.username} in {self.username}\'s handler')
+                return
             except Exception:
                 log.exception(f'Error when processing message: {message}')
                 return
@@ -119,8 +125,8 @@ class ClientHandler(abc.ABC):
         try:
             self.writer.write(message.to_data())
             await self.writer.drain()
-        except ConnectionError:
-            raise StopHandlerException()
+        except ConnectionError as e:
+            raise SendMessageException(self.username) from e
 
     async def authenticate_user(self, username, password) -> DbUser | None:
         is_guest = utils.is_guest(username, password)
@@ -141,6 +147,14 @@ class ClientHandler(abc.ABC):
     def close_and_stop(self):
         self.close()
         raise StopHandlerException()
+
+
+class SendMessageException(Exception):
+    username: str | None
+
+    def __init__(self, username: str | None):
+        super().__init__(f'Failed to send message to {username}')
+        self.username = username
 
 
 class StopHandlerException(Exception):


### PR DESCRIPTION
This exception can be used instead of StopHandlerException() for errors when sending messages. It additionally contains information about the user to which the message was meant to be sent.

This information is later used to check if we caught the exception for a different or the same user. In case of the same user, we can safely stop the handler. In case of a different user, the exception should be caught before the handler run loop.