### PR TITLE
Handle send errors when challenging a user

### DIFF
--- a/server/src/QRServer/lobby/lobbyclient.py
+++ b/server/src/QRServer/lobby/lobbyclient.py
@@ -104,7 +104,10 @@ class LobbyClientHandler(ClientHandler):
         challenger_idx = message.get_challenger_idx()
         challenged_idx = message.get_challenged_idx()
         log.debug('Challenge issued')
-        await self.lobby_server.challenge_user(challenger_idx, challenged_idx)
+        success = await self.lobby_server.challenge_user(challenger_idx, challenged_idx)
+        if not success:
+            log.warning(f'Failed to challenge {challenged_idx} by {challenger_idx}')
+            await self.send_msg(LobbyChatMessage.new(None, 'Could not challenge the user'))
 
     async def _handle_challenge_auth(self, message: ChallengeAuthMessage):
         challenger_idx = message.get_challenger_idx()

--- a/server/src/QRServer/lobby/lobbyserver.py
+++ b/server/src/QRServer/lobby/lobbyserver.py
@@ -2,6 +2,7 @@ import logging
 from datetime import datetime, timezone
 
 from QRServer.common.classes import LobbyPlayer
+from QRServer.common.clienthandler import SendMessageException
 from QRServer.common.messages import ResponseMessage, LastLoggedResponse, LobbyStateResponse, ChallengeMessage, \
     ChallengeAuthMessage
 from QRServer.lobby.lobbyclient import LobbyClientHandler
@@ -34,6 +35,10 @@ class LobbyServer:
         return to_kick_idx
 
     async def remove_client(self, idx):
+        if self.clients[idx] is None:
+            log.warning(f'Not removing client {idx} as it\'s already gone')
+            return
+
         self.last_logged = self.clients[idx]
         self.clients[idx].close()
         self.clients[idx] = None
@@ -76,9 +81,21 @@ class LobbyServer:
                 await self.clients[i].send_msg(message)
         pass
 
-    async def challenge_user(self, challenger_idx, challenged_idx):
-        if self.clients[challenger_idx] and self.clients[challenged_idx]:
-            await self.clients[challenged_idx].send_msg(ChallengeMessage.new(challenged_idx, challenger_idx))
+    async def challenge_user(self, challenger_idx, challenged_idx) -> bool:
+        """
+        Returns True when the user has been challenged successfully, False otherwise.
+        """
+
+        message = ChallengeMessage.new(challenged_idx, challenger_idx)
+        try:
+            if self.clients[challenger_idx] and self.clients[challenged_idx]:
+                await self.clients[challenged_idx].send_msg(message)
+                return True
+        except SendMessageException as e:
+            log.warning(f'Failed to send {message} to {e.username}, kicking them')
+            await self.remove_client(challenged_idx)
+
+        return False
 
     async def setup_challenge(self, challenger_idx, challenged_idx, challenger_auth):
         if self.clients[challenger_idx] and self.clients[challenged_idx]:

--- a/server/tests/it/__init__.py
+++ b/server/tests/it/__init__.py
@@ -41,6 +41,24 @@ class TestClientConnection:
         self.writer.close()
         await self.writer.wait_closed()
 
+    async def drop(self):
+        server_client = self._find_server_lobby_client()
+        if server_client is None:
+            return
+
+        async def broken_drain():
+            raise ConnectionResetError('Connection dropped')
+
+        # Patch the drain() method to simulate a situation where the connection
+        # is abruptly interrupted when sending the message.
+        server_client.writer.drain = broken_drain
+
+    def _find_server_lobby_client(self):
+        for client in self.server.lobby_server.clients:
+            if client and client.username == self.username:
+                return client
+        return None
+
     async def send_data(self, data: bytes):
         self.writer.write(data)
         await self.writer.drain()

--- a/server/tests/it/test_lobby.py
+++ b/server/tests/it/test_lobby.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from QRServer.common.classes import LobbyPlayer
 from QRServer.common.messages import JoinLobbyRequest, LobbyStateResponse, LobbyDuplicateResponse, SetCommentRequest, \
     BroadcastCommentResponse, NameTakenRequest, NameTakenResponseYes, NameTakenResponseNo, ChangePasswordRequest, \
-    ChangePasswordResponseOk, LobbyBadMemberResponse
+    ChangePasswordResponseOk, LobbyBadMemberResponse, ChallengeMessage, LobbyChatMessage
 from . import QuadradiusIntegrationTestCase
 
 
@@ -282,3 +282,31 @@ class LobbyIT(QuadradiusIntegrationTestCase):
         client = await self.new_lobby_client()
         await client.send_message(ChangePasswordRequest.new('912ec803b2ce49e4a541068d495ab570'))
         await client.assert_no_more_messages()
+
+    async def test_lobby_challenge_user(self):
+        first_client = await self.new_lobby_client()
+        await first_client.join_lobby('First Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        second_client = await self.new_lobby_client()
+        await second_client.join_lobby('Second Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        await first_client.assert_received_message_type(LobbyStateResponse)
+
+        challenge_message = ChallengeMessage.new(challenged_idx=0, challenger_idx=1)
+        await second_client.send_message(challenge_message)
+        await first_client.assert_received_message(challenge_message)
+
+    async def test_lobby_send_error_challenge_user(self):
+        first_client = await self.new_lobby_client()
+        await first_client.join_lobby('First Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        second_client = await self.new_lobby_client()
+        await second_client.join_lobby('Second Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        await first_client.drop()
+
+        await second_client.send_message(ChallengeMessage.new(challenged_idx=0, challenger_idx=1))
+        await second_client.assert_received_message_type(LobbyStateResponse)
+        await second_client.assert_received_message(LobbyChatMessage.new(None, 'Could not challenge the user'))
+        await second_client.assert_no_more_messages()
+        await first_client.wait_for_disconnect()


### PR DESCRIPTION
When challenging a user, the challenge message can error out, in which case we'll remove the challenged user from the lobby and send a message to the challenging user.