### PR TITLE
Handle send errors when broadcasting lobby state

### DIFF
--- a/server/src/QRServer/lobby/lobbyserver.py
+++ b/server/src/QRServer/lobby/lobbyserver.py
@@ -34,7 +34,7 @@ class LobbyServer:
         await self.remove_client(to_kick_idx)
         return to_kick_idx
 
-    async def remove_client(self, idx):
+    async def remove_client(self, idx, excluded_idx=None):
         if self.clients[idx] is None:
             log.warning(f'Not removing client {idx} as it\'s already gone')
             return
@@ -42,7 +42,10 @@ class LobbyServer:
         self.last_logged = self.clients[idx]
         self.clients[idx].close()
         self.clients[idx] = None
-        await self.broadcast_lobby_state(idx)
+
+        if excluded_idx is None:
+            excluded_idx = idx
+        await self.broadcast_lobby_state(excluded_idx)
 
     def username_exists(self, username):
         for i in self.clients:
@@ -77,9 +80,16 @@ class LobbyServer:
         for i in range(13):
             if i == excluded_idx:
                 continue
-            if self.clients[i]:
-                await self.clients[i].send_msg(message)
-        pass
+            try:
+                if self.clients[i]:
+                    await self.clients[i].send_msg(message)
+            except SendMessageException as e:
+                log.warning(f'Failed to send lobby state to {e.username} ({i}), kicking them')
+                # Removing client will rebroadcast lobby state. Just make sure
+                # the original idx is excluded in order not to send spurious
+                # messages.
+                await self.remove_client(i, excluded_idx)
+                return
 
     async def challenge_user(self, challenger_idx, challenged_idx) -> bool:
         """

--- a/server/tests/it/test_lobby.py
+++ b/server/tests/it/test_lobby.py
@@ -337,3 +337,43 @@ class LobbyIT(QuadradiusIntegrationTestCase):
         await first_client.assert_received_message(LobbyChatMessage.new(None, 'Could not respond to the challenge'))
         await first_client.assert_no_more_messages()
         await second_client.wait_for_disconnect()
+
+    async def test_lobby_lobby_state_send_error(self):
+        first_client = await self.new_lobby_client()
+        await first_client.join_lobby('First Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        second_client = await self.new_lobby_client()
+        await second_client.join_lobby('Second Player', 'cf585d509bf09ce1d2ff5d4226b7dacb')
+
+        await first_client.assert_received_message_type(LobbyStateResponse)
+
+        await second_client.drop()
+
+        third_client = await self.new_lobby_client()
+        await third_client.send_message(JoinLobbyRequest.new('Third Player', 'cf585d509bf09ce1d2ff5d4226b7dacb'))
+
+        # Now sending the message to first_client should succeed.
+
+        await first_client.assert_received_message(LobbyStateResponse.new([
+            LobbyPlayer(username='First Player'),
+            LobbyPlayer(username='Second Player'),
+            LobbyPlayer(username='Third Player'),
+        ]))
+
+        # Sending the message to the second client should fail, it should be
+        # removed, and we should send updated messages to all of them.
+
+        await first_client.assert_received_message(LobbyStateResponse.new([
+            LobbyPlayer(username='First Player'),
+            None,
+            LobbyPlayer(username='Third Player'),
+        ]))
+        await second_client.wait_for_disconnect()
+        await third_client.assert_received_message(LobbyStateResponse.new([
+            LobbyPlayer(username='First Player'),
+            None,
+            LobbyPlayer(username='Third Player'),
+        ]))
+
+        await first_client.assert_no_more_messages()
+        await third_client.assert_no_more_messages()


### PR DESCRIPTION
When a send error occurs, kick the player and rebroadcast.