### PR TITLE
fix: remove cyclic import

### DIFF
--- a/server/src/QRServer/config_handlers.py
+++ b/server/src/QRServer/config_handlers.py
@@ -1,10 +1,10 @@
 import logging
 import os
 
-from QRServer.discord import logger as discord_logger
-
 
 def refresh_logger_configuration(config):
+    from QRServer.discord import logger as discord_logger
+
     log_level = logging.DEBUG if config.log_verbose.get() else logging.INFO
 
     if config.log_long.get():


### PR DESCRIPTION
You can verify the issue by running `pytest` in `server/` directory, then `pytest tests/test_db.py::DbTest::test_add_match_results` to run a single test.