### PR TITLE
Use hmac.compare_digest() for password hash comparison

### DIFF
--- a/server/src/QRServer/db/password.py
+++ b/server/src/QRServer/db/password.py
@@ -1,5 +1,6 @@
 import binascii
 import hashlib
+import hmac
 import os
 
 _iterations = 100000
@@ -29,4 +30,4 @@ def password_verify(provided_password: bytes | None, stored_hash: str | None) ->
         salt.encode('ascii'),
         _iterations)
     h_str = binascii.hexlify(h).decode('ascii')
-    return h_str == stored_hash
+    return hmac.compare_digest(h_str, stored_hash)


### PR DESCRIPTION
Prevents timing attacks by using a constant-time comparison instead of a direct string equality check.