### PR TITLE
chore: split matches table into matches and match_results

### DIFF
--- a/server/src/QRServer/db/connector.py
+++ b/server/src/QRServer/db/connector.py
@@ -179,9 +179,28 @@ class DbConnector:
 
     async def add_match_result(self, match_result: DbMatchReport):
         async with self._transaction("w") as c:
+            user_1, user_2 = sorted((match_result.winner_id, match_result.loser_id))
+
             await c.execute(
                 "insert into matches ("
                 "  id,"
+                "  user_1,"
+                "  user_2,"
+                "  is_ranked,"
+                "  started_at"
+                ") values ("
+                "?, ?, ?, ?, ?"
+                ")", (
+                    match_result.match_id,
+                    user_1,
+                    user_2,
+                    match_result.is_ranked,
+                    match_result.started_at.timestamp(),
+                ))
+
+            await c.execute(
+                "insert into match_results ("
+                "  match_id,"
                 "  winner_id,"
                 "  loser_id,"
                 "  winner_pieces_left,"
@@ -189,13 +208,11 @@ class DbConnector:
                 "  move_counter,"
                 "  grid_size,"
                 "  squadron_size,"
-                "  started_at,"
                 "  finished_at,"
-                "  is_ranked,"
                 "  is_void"
                 ") values ("
-                "?, ?, ?, ?, ?, ?,"
-                "?, ?, ?, ?, ?, ?"
+                "?, ?, ?, ?, ?,"
+                "?, ?, ?, ?, ?"
                 ")", (
                     match_result.match_id,
                     match_result.winner_id,
@@ -205,10 +222,8 @@ class DbConnector:
                     match_result.move_counter,
                     match_result.grid_size,
                     match_result.squadron_size,
-                    match_result.started_at.timestamp(),
                     match_result.finished_at.timestamp(),
-                    match_result.is_ranked,
-                    match_result.is_void
+                    match_result.is_void,
                 ))
 
             start_date, end_date = utils.make_month_dates(
@@ -232,9 +247,11 @@ class DbConnector:
             await c.execute(
                 "select id, winner_id, loser_id, winner_pieces_left,"
                 " loser_pieces_left, move_counter, grid_size,"
-                " squadron_size, started_at, finished_at, is_ranked,"
+                " squadron_size, m.started_at, finished_at, m.is_ranked,"
                 " is_void"
-                " from matches where id = ?", (
+                " from matches m"
+                " left join match_results r on m.id = r.match_id"
+                " where id = ?", (
                     match_id,
                 ))
             row = await c.fetchone()
@@ -261,14 +278,15 @@ class DbConnector:
                 "select"
                 " u1.username,"
                 " u2.username,"
-                " m.winner_pieces_left,"
-                " m.loser_pieces_left,"
+                " r.winner_pieces_left,"
+                " r.loser_pieces_left,"
                 " m.started_at,"
-                " m.finished_at,"
-                " m.move_counter"
+                " r.finished_at,"
+                " r.move_counter"
                 " from matches m"
-                " left join users u1 on m.winner_id = u1.id"
-                " left join users u2 on m.loser_id = u2.id"
+                " left join match_results r on m.id = r.match_id"
+                " left join users u1 on r.winner_id = u1.id"
+                " left join users u2 on r.loser_id = u2.id"
                 " where m.id = ?", (match_id,))
 
             row = await c.fetchone()
@@ -290,16 +308,17 @@ class DbConnector:
             await c.execute("select"
                             " u1.username,"
                             " u2.username,"
-                            " m.winner_pieces_left,"
-                            " m.loser_pieces_left,"
+                            " r.winner_pieces_left,"
+                            " r.loser_pieces_left,"
                             " m.started_at,"
-                            " m.finished_at,"
-                            " m.move_counter"
+                            " r.finished_at,"
+                            " r.move_counter"
                             " from matches m"
-                            " left join users u1 on m.winner_id = u1.id"
-                            " left join users u2 on m.loser_id = u2.id"
-                            " where m.is_void = 0"
-                            " order by m.finished_at desc"
+                            " left join match_results r on m.id = r.match_id"
+                            " left join users u1 on r.winner_id = u1.id"
+                            " left join users u2 on r.loser_id = u2.id"
+                            " where r.is_void = 0"
+                            " order by r.finished_at desc"
                             " limit ?", (count,))
 
             recent_matches = []
@@ -384,15 +403,16 @@ class DbConnector:
                 "select"
                 " u.username,"
                 " u.id,"
-                " sum(m.winner_id = u.id) as total_wins,"
+                " sum(mr.winner_id = u.id) as total_wins,"
                 " count(*) as total_games"
                 " from users u"
-                " inner join matches m on (u.id = m.winner_id or u.id = m.loser_id)"
+                " inner join match_results mr on (u.id = mr.winner_id or u.id = mr.loser_id)"
+                " inner join matches m on m.id = mr.match_id"
                 " inner join user_ratings r on (u.id = r.user_id) and r.month = ? and r.year = ?"
-                " where m.finished_at >= ?"
-                " and m.finished_at < ?"
+                " where mr.finished_at >= ?"
+                " and mr.finished_at < ?"
                 " and (case when ? = 1 then m.is_ranked = 1 else 1=1 end)"
-                " and (case when ? = 0 then m.is_void = 0 else 1=1 end)"
+                " and (case when ? = 0 then mr.is_void = 0 else 1=1 end)"
                 " group by u.username"
                 " order by rating desc, total_games desc, total_wins desc, u.id desc"
                 " limit 100", (
@@ -724,11 +744,12 @@ class DbConnector:
             await c.execute(
                 "select id, winner_id, loser_id, winner_pieces_left,"
                 " loser_pieces_left, move_counter, grid_size,"
-                " squadron_size, started_at, finished_at, is_ranked,"
-                " is_void"
-                " from matches"
+                " squadron_size, m.started_at, finished_at, m.is_ranked,"
+                " r.is_void"
+                " from matches m"
                 " right join tournament_matches"
-                " on matches.id = tournament_matches.match_id"
+                " on m.id = tournament_matches.match_id"
+                " left join match_results r on m.id = r.match_id"
                 " where tournament_matches.tournament_id = ? and tournament_matches.duel_idx = ?",
                 (
                     tournament_id,
@@ -759,15 +780,16 @@ class DbConnector:
     async def list_tournament_matches(self, tournament_id: str) -> list[TournamentMatch] | None:
         async with self._transaction("r") as c:
             await c.execute(
-                "select matches.id, winner_id, loser_id, winner_pieces_left,"
+                "select m.id, winner_id, loser_id, winner_pieces_left,"
                 " loser_pieces_left, move_counter, grid_size,"
-                " squadron_size, matches.started_at, matches.finished_at, is_ranked,"
-                " is_void, duel_idx"
+                " squadron_size, m.started_at, r.finished_at, m.is_ranked,"
+                " r.is_void, duel_idx"
                 " from tournaments"
                 " left join tournament_matches"
                 " on tournaments.id = tournament_matches.tournament_id"
-                " left join matches"
-                " on matches.id = tournament_matches.match_id"
+                " left join matches m"
+                " on m.id = tournament_matches.match_id"
+                " left join match_results r on m.id = r.match_id"
                 " where tournaments.id = ?",
                 (tournament_id,)
             )

--- a/server/src/QRServer/db/migrations.py
+++ b/server/src/QRServer/db/migrations.py
@@ -30,6 +30,7 @@ async def execute_migrations(transaction, config: Config, max_version=None):
         _migration_upgrade_to_v6,
         _migration_upgrade_to_v7,
         _migration_upgrade_to_v8,
+        _migration_upgrade_to_v9,
     ]
 
     for i in range(max_version if max_version and max_version <= len(migrations) else len(migrations)):
@@ -259,3 +260,30 @@ async def _migration_upgrade_to_v8(c, _config):
     )
 
     await _set_version(c, 8)
+
+
+async def _migration_upgrade_to_v9(c, _config):
+    await c.execute("alter table matches rename to match_results")
+
+    await c.execute(
+        "create table matches ("
+        "  id varchar primary key,"
+        "  user_1 varchar,"
+        "  user_2 varchar,"
+        "  is_ranked integer,"
+        "  started_at integer,"
+        "  foreign key(user_1) references users (id),"
+        "  foreign key(user_2) references users (id)"
+        ")")
+
+    await c.execute(
+        "insert into matches (id, user_1, user_2, is_ranked, started_at)"
+        " select id,"
+        "   case when winner_id < loser_id then winner_id else loser_id end,"
+        "   case when winner_id < loser_id then loser_id else winner_id end,"
+        "   is_ranked, started_at"
+        " from match_results")
+
+    await c.execute("alter table match_results rename column id to match_id")
+
+    await _set_version(c, 9)

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -673,6 +673,144 @@ class DbMigrationTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(table_info[1][:3], (1, 'duel_idx', 'INTEGER'))
         self.assertEqual(table_info[2][:3], (2, 'match_id', 'varchar'))
 
+    async def test_migration_v9(self):
+        await migrations.execute_migrations(self.transaction, self.dbconn.config, 8)
+
+        table_names = await self.get_table_names()
+        self.assertNotIn('match_results', table_names)
+
+        table_info = await self.get_table_info('matches')
+        self.assertEqual(len(table_info), 12)
+        self.assertEqual(table_info[0][:3], (0, 'id', 'varchar'))
+        self.assertEqual(table_info[1][:3], (1, 'winner_id', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'loser_id', 'varchar'))
+        self.assertEqual(table_info[3][:3], (3, 'winner_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[4][:3], (4, 'loser_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[5][:3], (5, 'move_counter', 'INTEGER'))
+        self.assertEqual(table_info[6][:3], (6, 'grid_size', 'varchar'))
+        self.assertEqual(table_info[7][:3], (7, 'squadron_size', 'varchar'))
+        self.assertEqual(table_info[8][:3], (8, 'started_at', 'INTEGER'))
+        self.assertEqual(table_info[9][:3], (9, 'finished_at', 'INTEGER'))
+        self.assertEqual(table_info[10][:3], (10, 'is_ranked', 'INTEGER'))
+        self.assertEqual(table_info[11][:3], (11, 'is_void', 'INTEGER'))
+
+        async def make_user(id_: str, username: str):
+            async with self.transaction('w') as c:
+                await c.execute(
+                    "insert or ignore into users(id, username, password, created_at, discord_user_id"
+                    ") values (?, ?, ?, ?, ?)",
+                    (id_, username, password_hash(b'password'), datetime.now(timezone.utc).timestamp(), None)
+                )
+
+        await make_user('1', 'test_user_1')
+        await make_user('2', 'test_user_2')
+
+        test_match = DbMatchReport(
+            winner_id='1',
+            loser_id='2',
+            winner_pieces_left=10,
+            loser_pieces_left=5,
+            move_counter=20,
+            grid_size='small',
+            squadron_size='medium',
+            started_at=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+            finished_at=datetime(2020, 1, 1, 1, 0, 0, tzinfo=timezone.utc),
+            is_ranked=True,
+            is_void=False,
+            match_id='1234',
+        )
+        async with self.transaction('w') as c:
+            await c.execute(
+                "insert into matches ("
+                "  id,"
+                "  winner_id,"
+                "  loser_id,"
+                "  winner_pieces_left,"
+                "  loser_pieces_left,"
+                "  move_counter,"
+                "  grid_size,"
+                "  squadron_size,"
+                "  started_at,"
+                "  finished_at,"
+                "  is_ranked,"
+                "  is_void"
+                ") values ("
+                "?, ?, ?, ?, ?, ?,"
+                "?, ?, ?, ?, ?, ?"
+                ")", (
+                    test_match.match_id,
+                    test_match.winner_id,
+                    test_match.loser_id,
+                    test_match.winner_pieces_left,
+                    test_match.loser_pieces_left,
+                    test_match.move_counter,
+                    test_match.grid_size,
+                    test_match.squadron_size,
+                    test_match.started_at.timestamp(),
+                    test_match.finished_at.timestamp(),
+                    test_match.is_ranked,
+                    test_match.is_void
+                )
+            )
+
+        await migrations.execute_migrations(self.transaction, self.dbconn.config, 9)
+
+        table_names = await self.get_table_names()
+        self.assertIn('matches', table_names)
+        self.assertIn('match_results', table_names)
+
+        table_info = await self.get_table_info('matches')
+        self.assertEqual(len(table_info), 5)
+        self.assertEqual(table_info[0][:3], (0, 'id', 'varchar'))
+        self.assertEqual(table_info[1][:3], (1, 'user_1', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'user_2', 'varchar'))
+        self.assertEqual(table_info[3][:3], (3, 'is_ranked', 'INTEGER'))
+        self.assertEqual(table_info[4][:3], (4, 'started_at', 'INTEGER'))
+
+        table_info = await self.get_table_info('match_results')
+        self.assertEqual(len(table_info), 12)
+        self.assertEqual(table_info[0][:3], (0, 'match_id', 'varchar'))
+        self.assertEqual(table_info[1][:3], (1, 'winner_id', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'loser_id', 'varchar'))
+        self.assertEqual(table_info[3][:3], (3, 'winner_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[4][:3], (4, 'loser_pieces_left', 'INTEGER'))
+        self.assertEqual(table_info[5][:3], (5, 'move_counter', 'INTEGER'))
+        self.assertEqual(table_info[6][:3], (6, 'grid_size', 'varchar'))
+        self.assertEqual(table_info[7][:3], (7, 'squadron_size', 'varchar'))
+        self.assertEqual(table_info[8][:3], (8, 'started_at', 'INTEGER'))
+        self.assertEqual(table_info[9][:3], (9, 'finished_at', 'INTEGER'))
+        self.assertEqual(table_info[10][:3], (10, 'is_ranked', 'INTEGER'))
+        self.assertEqual(table_info[11][:3], (11, 'is_void', 'INTEGER'))
+
+        async with self.transaction('r') as c:
+            await c.execute('select id, user_1, user_2, is_ranked, started_at from matches')
+            rows = await c.fetchall()
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row[0], '1234')
+            self.assertEqual(row[1], '1')
+            self.assertEqual(row[2], '2')
+            self.assertEqual(row[3], 1)
+            self.assertEqual(row[4], 1577836800)
+
+            await c.execute(
+                'select match_id, winner_id, loser_id, winner_pieces_left, loser_pieces_left,'
+                ' move_counter, grid_size, squadron_size, finished_at, is_void from match_results',
+            )
+            rows = await c.fetchall()
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row[0], '1234')
+            self.assertEqual(row[1], '1')
+            self.assertEqual(row[2], '2')
+            self.assertEqual(row[3], 10)
+            self.assertEqual(row[4], 5)
+            self.assertEqual(row[5], 20)
+            self.assertEqual(row[6], 'small')
+            self.assertEqual(row[7], 'medium')
+            self.assertEqual(row[8], 1577840400)
+            self.assertEqual(row[9], 0)
+
 
 class DbTournamentsTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):


### PR DESCRIPTION
Initially we only stored match results for various purposes, mostly ranking-related. Match table actually stores match results, and only saves them at the end of the match, which is a problem for recording system, which requires match_id to exist from the start of the match. Splitting this table will allow us to insert matches independently from results and in future add recordings.