### PR TITLE
chore: handle nonexistent config

### DIFF
--- a/server/src/QRServer/config.py
+++ b/server/src/QRServer/config.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
@@ -6,6 +7,7 @@ from typing import Any, Callable
 import toml
 
 from QRServer import config_handlers
+log = logging.getLogger('qr.config')
 
 
 @dataclass
@@ -250,7 +252,12 @@ class Config:
         return conf
 
     def set(self, name: str, value: str | int):
-        key = self.get_key(name)
+        try:
+            key = self.get_key(name)
+        except Exception as e:
+            log.warning(f'Unsupported config key detected, omitting: {e}')
+            return
+
         value_type = key.get_type()
 
         if value is None:


### PR DESCRIPTION
Currently if user specifies config entries which are not recognized by qr the server will crash. This is impractical, especially when developing new features, when we want to have relevant configuration prepared ahead of merge and ensure that the server still starts up