### PR TITLE
fix: always respond to discord users' interaction when banning

### DIFF
--- a/server/src/QRServer/discord/bot.py
+++ b/server/src/QRServer/discord/bot.py
@@ -294,10 +294,15 @@ class DiscordBot:
 
         if not user.discord_user_id:
             await interaction.response.send_message(
+                f"Banned user: `{username}`.\n"
                 "This user has no Discord ID",
                 ephemeral=True,
             )
             return
+        else:
+            await interaction.response.send_message(
+                f"Banned user: `{username}`.", ephemeral=True
+            )
 
         if not user.is_banned:
             discord_user = await self.client.fetch_user(int(user.discord_user_id))
@@ -343,10 +348,16 @@ class DiscordBot:
 
         if not user.discord_user_id:
             await interaction.response.send_message(
+                f"Unbanned user: `{username}`.\n"
                 "This user has no Discord ID",
                 ephemeral=True,
             )
             return
+        else:
+            await interaction.response.send_message(
+                f"Unbanned user: `{username}`.",
+                ephemeral=True,
+            )
 
         discord_user = await self.client.fetch_user(int(user.discord_user_id))
         await discord_user.send(

--- a/server/tests/test_discord_bot.py
+++ b/server/tests/test_discord_bot.py
@@ -241,7 +241,7 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
 
         await self.bot._ban_user(self.interaction, self.username, 'Test Ban')
 
-        self.interaction.response.send_message.assert_not_called()
+        self.interaction.response.send_message.assert_called_once_with('Banned user: `test_user`.', ephemeral=True)
         self.interaction.user.send.assert_not_called()
 
         self.bot._send_notification.assert_called_once_with(
@@ -281,7 +281,7 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
         self.bot.client.fetch_user.return_value = user_sender_mock
         await self.bot._ban_user(self.interaction, self.username, 'Test Ban')
 
-        self.interaction.response.send_message.assert_not_called()
+        self.interaction.response.send_message.assert_called_once_with('Banned user: `test_user`.', ephemeral=True)
         self.interaction.user.send.assert_not_called()
 
         self.bot._send_notification.assert_called_once_with(
@@ -303,7 +303,7 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
 
         await self.bot._unban_user(self.interaction, self.username)
 
-        self.interaction.response.send_message.assert_not_called()
+        self.interaction.response.send_message.assert_called_once_with('Unbanned user: `test_user`.', ephemeral=True)
         self.interaction.user.send.assert_not_called()
 
         self.bot._send_notification.assert_called_once_with(
@@ -351,7 +351,8 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
         await self.bot._ban_user(self.interaction, self.username, 'Test Ban')
 
         self.interaction.response.send_message.assert_called_once_with(
-            'This user has no Discord ID',
+            "Banned user: `test_user`.\n"
+            "This user has no Discord ID",
             ephemeral=True,
         )
         self.interaction.user.send.assert_not_called()
@@ -376,7 +377,8 @@ class DiscordBotTest(unittest.IsolatedAsyncioTestCase):
         await self.bot._unban_user(self.interaction, self.username)
 
         self.interaction.response.send_message.assert_called_once_with(
-            'This user has no Discord ID',
+            "Unbanned user: `test_user`.\n"
+            "This user has no Discord ID",
             ephemeral=True,
         )
         self.interaction.user.send.assert_not_called()


### PR DESCRIPTION
Not responding to interaction does not cause any errors, but shows up in Discord as "Application did not respond", which may be confusing.