### PR TITLE
chore: switch logLevel from debug to info for ruffle

### DIFF
--- a/web/public/config-ruffle.js
+++ b/web/public/config-ruffle.js
@@ -5,7 +5,7 @@ window.RufflePlayer = window.RufflePlayer || {};
 window.RufflePlayer.config = {
     autoplay: "on",
     contextMenu: "off",
-    logLevel: "debug",
+    logLevel: "info",
     socketProxy: [
         {
             host: "127.0.0.1",


### PR DESCRIPTION
Others do not really need this info and we can enable it for ourselves easily. Disabling this makes the game run slightly faster