### PR TITLE
chore: move oauth endpoint to api/v1

### DIFF
--- a/server/src/QRServer/api/api.py
+++ b/server/src/QRServer/api/api.py
@@ -78,7 +78,7 @@ class ApiServer:
 
             # OAuth2
             web.get('/.well-known/openid-configuration', self._wellknown_openid_config),
-            web.post('/oauth/token', self._oauth_token),
+            web.post('/api/v1/oauth/token', self._v1_oauth_token),
         ])
 
     async def _v1_game_stats(self, _request: web.Request) -> web.Response:
@@ -177,14 +177,14 @@ class ApiServer:
         base = f'{self.origin}'
         return web.json_response({
             'issuer': base,
-            'token_endpoint': f'{base}/oauth/token',
-            'userinfo_endpoint': f'{base}/oauth/userinfo',
+            'token_endpoint': f'{base}/api/v1/oauth/token',
+            'userinfo_endpoint': f'{base}/api/v1/oauth/userinfo',
             'response_types_supported': ['token'],
             'grant_types_supported': ['password', 'refresh_token'],
             'token_endpoint_auth_methods_supported': ['none'],
         })
 
-    async def _oauth_token(self, request: web.Request) -> web.Response:
+    async def _v1_oauth_token(self, request: web.Request) -> web.Response:
         content_type = request.content_type
 
         if 'application/json' in content_type:

--- a/server/tests/it/test_api_oauth.py
+++ b/server/tests/it/test_api_oauth.py
@@ -24,7 +24,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
             )
 
     async def _login(self, client, username='testuser', password='asd'):
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'password',
             'username': username,
             'password': md5(f'++{username.upper()}++{password}'.encode()).hexdigest(),
@@ -39,8 +39,8 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
             doc = await r.json()
 
         self.assertEqual(doc['issuer'], 'http://localhost')
-        self.assertEqual(doc['token_endpoint'], 'http://localhost/oauth/token')
-        self.assertEqual(doc['userinfo_endpoint'], 'http://localhost/oauth/userinfo')
+        self.assertEqual(doc['token_endpoint'], 'http://localhost/api/v1/oauth/token')
+        self.assertEqual(doc['userinfo_endpoint'], 'http://localhost/api/v1/oauth/userinfo')
         self.assertEqual(doc['response_types_supported'], ['token'])
         self.assertEqual(doc['grant_types_supported'], ['password', 'refresh_token'])
         self.assertEqual(doc['token_endpoint_auth_methods_supported'], ['none'])
@@ -49,7 +49,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
     async def test_password_grant_missing_body(self):
         client = await self.new_api_client('v1')
 
-        async with client.post('/oauth/token') as r:
+        async with client.post('/api/v1/oauth/token') as r:
             self.assertEqual(r.status, 400)
             self.assertEqual((await r.json())['error'], 'invalid_request')
 
@@ -57,7 +57,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
         client = await self.new_api_client('v1')
 
         # Missing field
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'password',
             'username': 'testuser',
         }) as r:
@@ -65,7 +65,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
             self.assertEqual((await r.json())['error'], 'invalid_request')
 
         # Value present but set to None
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'password',
             'username': 'testuser',
             'password': None
@@ -126,7 +126,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
     async def test_unsupported_grant_type(self):
         client = await self.new_api_client('v1')
 
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'authorization_code',
             'code': 'asd',
         }) as r:
@@ -142,7 +142,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
         self.assertEqual(status, 200)
         refresh_token = body['refresh_token']
 
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'refresh_token',
             'refresh_token': refresh_token,
         }) as r:
@@ -162,7 +162,7 @@ class ApiOauthIT(QuadradiusIntegrationTestCase):
     async def test_refresh_grant_invalid_token(self):
         client = await self.new_api_client('v1')
 
-        async with client.post('/oauth/token', json={
+        async with client.post('/api/v1/oauth/token', json={
             'grant_type': 'refresh_token',
             'refresh_token': 'asd',
         }) as r:


### PR DESCRIPTION
Separating oauth from the rest of the api does not make sense.