### PR TITLE
chore: separate match creation from uploading match result

### DIFF
--- a/server/src/QRServer/db/connector.py
+++ b/server/src/QRServer/db/connector.py
@@ -202,9 +202,16 @@ class DbConnector:
                     user_id,
                 ))
 
-    async def add_match_result(self, match_result: DbMatchReport):
+    async def create_match_and_add_result(self, match_result: DbMatchReport):
+        await self.create_match(
+            match_result.match_id, match_result.started_at, match_result.winner_id, match_result.loser_id,
+            match_result.is_ranked,
+        )
+        await self.add_match_result(match_result)
+
+    async def create_match(self, match_id: str, started_at: datetime, user_1_id: str, user_2_id: str, is_ranked: bool):
         async with self._transaction("w") as c:
-            user_1, user_2 = sorted((match_result.winner_id, match_result.loser_id))
+            user_1, user_2 = sorted((user_1_id, user_2_id))
 
             await c.execute(
                 "insert into matches ("
@@ -216,13 +223,15 @@ class DbConnector:
                 ") values ("
                 "?, ?, ?, ?, ?"
                 ")", (
-                    match_result.match_id,
+                    match_id,
                     user_1,
                     user_2,
-                    match_result.is_ranked,
-                    match_result.started_at.timestamp(),
+                    is_ranked,
+                    int(started_at.timestamp()),
                 ))
 
+    async def add_match_result(self, match_result: DbMatchReport):
+        async with self._transaction("w") as c:
             await c.execute(
                 "insert into match_results ("
                 "  match_id,"
@@ -251,11 +260,14 @@ class DbConnector:
                     match_result.is_void,
                 ))
 
-            start_date, end_date = utils.make_month_dates(
-                month=match_result.finished_at.month, year=match_result.finished_at.year)
+        await self._post_match(match_result)
 
-            ranked_only = self.config.leaderboards_ranked_only.get()
-            include_void = self.config.leaderboards_include_void.get()
+    async def _post_match(self,  match_result: DbMatchReport):
+        start_date, end_date = utils.make_month_dates(
+            month=match_result.finished_at.month, year=match_result.finished_at.year)
+
+        ranked_only = self.config.leaderboards_ranked_only.get()
+        include_void = self.config.leaderboards_include_void.get()
 
         if (match_result.is_ranked or not ranked_only) and (not match_result.is_void or include_void):
             await self._update_users_rating(

--- a/server/src/QRServer/game/gameserver.py
+++ b/server/src/QRServer/game/gameserver.py
@@ -1,6 +1,7 @@
 import logging
 
 from QRServer.common.classes import MatchId, Match, MatchStats
+from QRServer.db.connector import DbConnector
 from QRServer.discord.webhook import Webhook
 from QRServer.game.gameclient import GameClientHandler
 
@@ -10,7 +11,7 @@ log = logging.getLogger('qr.game_server')
 class GameServer:
     matches: dict[MatchId, Match]
 
-    def __init__(self, config, connector):
+    def __init__(self, config, connector: DbConnector):
         self.config = config
         self.connector = connector
         self.webhook = Webhook(config)
@@ -47,13 +48,14 @@ class GameServer:
             try:
                 report = match.generate_match_report()
                 if report:
-                    await self.connector.add_match_result(report)
+                    await self.connector.create_match_and_add_result(report)
                     log.debug(f'Added match report {report}')
                     result = await self.connector.get_match_result(report.match_id)
-                    log.info(f'A match has ended; '
-                             f'{result.player_won} beat {result.player_lost} '
-                             f'{result.won_score}-{result.lost_score}')
-                    await self.webhook.invoke_webhook_game_ended(result)
+                    if result:
+                        log.info(f'A match has ended; '
+                                 f'{result.player_won} beat {result.player_lost} '
+                                 f'{result.won_score}-{result.lost_score}')
+                        await self.webhook.invoke_webhook_game_ended(result)
                 else:
                     log.error('Failed to generate report')
             except Exception:

--- a/server/tests/it/test_api_tournaments.py
+++ b/server/tests/it/test_api_tournaments.py
@@ -188,7 +188,7 @@ class ApiTournamentsIT(QuadradiusIntegrationTestCase):
             is_void=False,
             match_id=match_id,
         )
-        await self.connector.add_match_result(match)
+        await self.connector.create_match_and_add_result(match)
         result = await self.connector.add_duel_match(tournament_id, 0, match_id)
         self.assertTrue(result)
 

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -38,7 +38,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(user.created_at, datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc).timestamp())
             self.assertTrue(user.is_guest)
 
-    async def test_add_match_results(self):
+    async def test_create_match_and_add_result(self):
         with patch('uuid.uuid4') as mock_uuid:
             mock_uuid.return_value = '1'
             winner = await self.conn.authenticate_user('test_user_1', b'password', auto_create=True)
@@ -60,8 +60,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                 is_ranked=True,
                 is_void=False,
             )
-
-            await self.conn.add_match_result(test_match)
+            await self.conn.create_match_and_add_result(test_match)
             match = await self.conn.get_match(test_match.match_id)
 
             self.assertEqual(match.match_id, '1234')
@@ -129,7 +128,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
                 recent_matches.append(
                     GameResultHistory(
                         player_won=f'test_user_{i}',
@@ -184,7 +183,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 5 matches for user 1 in month 1
             for i in range(1, 6):
@@ -203,7 +202,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 10 matches for user 2 in month 1
             for i in range(1, 11):
@@ -222,7 +221,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 10 matches for user 2 in month 2
             for i in range(1, 11):
@@ -241,7 +240,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 2 unranked matches in month 1
             for i in range(1, 3):
@@ -260,7 +259,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 3 ranked void matches
             for i in range(1, 4):
@@ -279,7 +278,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=True,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             ranking_entries = [
                 RankingEntry(username='test_user_0', user_id='0', wins=7, games=7, rating=640),
@@ -325,7 +324,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 2 matches for user_2 (winner) vs user_1 (loser)
             for i in range(1, 3):
@@ -344,7 +343,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # Generate 5 matches for user_0 (winner) vs user_1 (loser) - user_1 lost some rating on user_2
             for i in range(1, 6):
@@ -363,7 +362,7 @@ class DbTest(unittest.IsolatedAsyncioTestCase):
                     is_void=False,
                 )
 
-                await self.conn.add_match_result(test_match)
+                await self.conn.create_match_and_add_result(test_match)
 
             # user_2 played less games than user_1,
             # but played against different players, therefore should have higher rating
@@ -1205,7 +1204,7 @@ class DbTournamentsTest(unittest.IsolatedAsyncioTestCase):
             is_ranked=True,
             is_void=False,
         )
-        await self.dbconn.add_match_result(match)
+        await self.dbconn.create_match_and_add_result(match)
         result = await self.dbconn.add_duel_match(tournament_id, 0, match.match_id)
 
         self.assertTrue(result)
@@ -1218,7 +1217,7 @@ class DbTournamentsTest(unittest.IsolatedAsyncioTestCase):
 
         match.match_id = str(uuid.uuid4())
 
-        await self.dbconn.add_match_result(match)
+        await self.dbconn.create_match_and_add_result(match)
         await self.dbconn.add_duel_match(tournament_id, 0, match.match_id)
 
         duel_matches = await self.dbconn.get_duel_matches(tournament_id, 0)


### PR DESCRIPTION
Currently we have a single db function responsible for inserting matches to db. To enable match creation at match start time we need to split this function into two separate stages