### PR TITLE
chore: rename user columns in matches

### DIFF
--- a/server/src/QRServer/db/connector.py
+++ b/server/src/QRServer/db/connector.py
@@ -211,21 +211,21 @@ class DbConnector:
 
     async def create_match(self, match_id: str, started_at: datetime, user_1_id: str, user_2_id: str, is_ranked: bool):
         async with self._transaction("w") as c:
-            user_1, user_2 = sorted((user_1_id, user_2_id))
+            user_1_id, user_2_id = sorted((user_1_id, user_2_id))
 
             await c.execute(
                 "insert into matches ("
                 "  id,"
-                "  user_1,"
-                "  user_2,"
+                "  user_1_id,"
+                "  user_2_id,"
                 "  is_ranked,"
                 "  started_at"
                 ") values ("
                 "?, ?, ?, ?, ?"
                 ")", (
                     match_id,
-                    user_1,
-                    user_2,
+                    user_1_id,
+                    user_2_id,
                     is_ranked,
                     int(started_at.timestamp()),
                 ))

--- a/server/src/QRServer/db/migrations.py
+++ b/server/src/QRServer/db/migrations.py
@@ -32,6 +32,7 @@ async def execute_migrations(transaction, config: Config, max_version=None):
         _migration_upgrade_to_v8,
         _migration_upgrade_to_v9,
         _migration_upgrade_to_v10,
+        _migration_upgrade_to_v11,
     ]
 
     for i in range(max_version if max_version and max_version <= len(migrations) else len(migrations)):
@@ -313,3 +314,10 @@ async def _migration_upgrade_to_v10(c, config):
     )
 
     await _set_version(c, 10)
+
+
+async def _migration_upgrade_to_v11(c, _config):
+    await c.execute("alter table matches rename column user_1 to user_1_id")
+    await c.execute("alter table matches rename column user_2 to user_2_id")
+
+    await _set_version(c, 11)

--- a/server/tests/test_db.py
+++ b/server/tests/test_db.py
@@ -990,6 +990,21 @@ class DbMigrationTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(table_info[4][:3], (4, 'source_discord_id', 'varchar'))
         self.assertEqual(table_info[5][:3], (5, 'ban_reason', 'varchar'))
 
+    async def test_migration_v11(self):
+        await migrations.execute_migrations(self.transaction, self.dbconn.config, 10)
+
+        table_info = await self.get_table_info('matches')
+        self.assertEqual(table_info[1][:3], (1, 'user_1', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'user_2', 'varchar'))
+
+        await migrations.execute_migrations(self.transaction, self.dbconn.config, 11)
+
+        table_info = await self.get_table_info('matches')
+        ver = await self.get_db_version()
+        self.assertEqual(ver, 11)
+        self.assertEqual(table_info[1][:3], (1, 'user_1_id', 'varchar'))
+        self.assertEqual(table_info[2][:3], (2, 'user_2_id', 'varchar'))
+
 
 class DbTournamentsTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):


### PR DESCRIPTION
Columns representing user_ids in new matches column were named in a way which suggested that they hold user object, instead of their id. This change corrects that, in line with the rest of db columns